### PR TITLE
Fix the datetime parsing to handle fractional seconds

### DIFF
--- a/src/youtube_id_search.py
+++ b/src/youtube_id_search.py
@@ -43,14 +43,32 @@ def _youtube_result_views_to_integer(youtube_views: str) -> int:
 
 def _youtube_result_duration_to_seconds(time_str: str) -> int:
     """Function to convert the youtube result duration format into the number of seconds."""
+    normalized_time_str = _get_normalized_time_str(time_str)
     # Parse time string
-    time_format = _find_time_string_format(time_str)
-    time_obj = datetime.strptime(time_str, time_format)
+    time_format = _find_time_string_format(normalized_time_str)
+    time_obj = datetime.strptime(normalized_time_str, time_format)
 
     # Calculate total duration in seconds
     total_seconds = time_obj.hour * 3600 + time_obj.minute * 60 + time_obj.second
 
     return total_seconds
+
+
+def _get_normalized_time_str(time_str):
+    # Handle fractional seconds: only remove if it's clearly fractional (after seconds in a time format)
+    # Look for pattern like "1:23.456" or "45.123" where the decimal part is likely fractional seconds
+    # But preserve "8.51" as "8:51" (minutes:seconds)
+    # If there's a decimal followed by 3+ digits, it's likely fractional seconds
+    if re.search(r'\.\d{3,}', time_str):
+        time_str = re.sub(r'\.\d+.*$', '', time_str)
+    # If format is like "XX.Y" where Y > 59, it's likely fractional seconds
+    elif re.search(r'\.\d{1,2}$', time_str):
+        match = re.search(r'\.(\d{1,2})$', time_str)
+        if match and int(match.group(1)) > 59:
+            time_str = re.sub(r'\.\d+.*$', '', time_str)
+    # Now normalize remaining dot separators to colon separators (e.g., "8.51" -> "8:51")
+    normalized_time_str = time_str.replace('.', ':')
+    return normalized_time_str
 
 
 def _find_time_string_format(time_str: str) -> str:


### PR DESCRIPTION
claude's solution to the error:
`
> poetry run python create_db_with_youtube_ids.py garbicz.csv                              
Finding Youtube IDs for the songs...
  0%|                                                                                                                                                                                    | 0/13 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/Users/frederik/dev/music-downloader/create_db_with_youtube_ids.py", line 93, in <module>
    main()
  File "/Users/frederik/dev/music-downloader/create_db_with_youtube_ids.py", line 64, in main
    search_results = get_youtube_search_results(search_string)
  File "/Users/frederik/dev/music-downloader/src/youtube_id_search.py", line 25, in get_youtube_search_results
    formatted_results = [
  File "/Users/frederik/dev/music-downloader/src/youtube_id_search.py", line 29, in <listcomp>
    "Duration (s)": _youtube_result_duration_to_seconds(
  File "/Users/frederik/dev/music-downloader/src/youtube_id_search.py", line 48, in _youtube_result_duration_to_seconds
    time_obj = datetime.strptime(time_str, time_format)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/_strptime.py", line 352, in _strptime
    raise ValueError("unconverted data remains: %s" %
ValueError: unconverted data remains: .52
`