### PR TITLE
artist-in-title --ait argument

### DIFF
--- a/download_tracks.py
+++ b/download_tracks.py
@@ -24,6 +24,12 @@ def main():
     parser.add_argument(
         "file_path", help="Path to a CSV file with the Youtube IDs", type=str
     )
+    
+    parser.add_argument(
+        "--ait", "--artist-in-title", 
+        action="store_true", 
+        help="Include artist name in track title metadata (format: 'ARTIST - TRACK TITLE')"
+    )
 
     args = parser.parse_args()
     if not args.file_path:
@@ -59,7 +65,7 @@ def main():
         # Set Metadata Tags for song title and artist
         file_extension = os.path.splitext(output_filepath)[1]
         metadata_tags = prepare_metadata_tags(
-            music_df_row=row, file_extension=file_extension
+            music_df_row=row, file_extension=file_extension, artist_in_title=args.ait
         )
         set_file_metadata_tags(filepath=output_filepath, metadata_tags=metadata_tags)
 

--- a/src/file_metadata.py
+++ b/src/file_metadata.py
@@ -10,6 +10,7 @@ from src.data_handling import (
     COLUMN_TRACK_NAME,
     COLUMN_GENRES,
     COLUMN_TEMPO,
+    get_song_search_string,
 )
 
 FILE_EXTENSION_MP3 = ".mp3"
@@ -38,7 +39,7 @@ METADATA_CLASSES = {
 }
 
 
-def prepare_metadata_tags(music_df_row: Dict, file_extension: str) -> dict:
+def prepare_metadata_tags(music_df_row: Dict, file_extension: str, artist_in_title: bool = False) -> dict:
     """This function prepares the metadata tags to be written onto a
     music file, depending on the file format."""
     artist_tag = METADATA_TAGS[file_extension]["artist"]
@@ -51,9 +52,15 @@ def prepare_metadata_tags(music_df_row: Dict, file_extension: str) -> dict:
     else:
         artist_names = music_df_row[COLUMN_ARTIST_NAME].split(",")
 
+    # Determine the title based on artist_in_title flag
+    if artist_in_title:
+        title = get_song_search_string(music_df_row)
+    else:
+        title = music_df_row[COLUMN_TRACK_NAME]
+
     return {
         artist_tag: artist_names,
-        title_tag: music_df_row[COLUMN_TRACK_NAME],
+        title_tag: title,
         genre_tag: music_df_row[COLUMN_GENRES],
         tempo_tag:  [round(float(music_df_row[COLUMN_TEMPO]))],
     }


### PR DESCRIPTION
> poetry run python download_tracks.py 2025august_with_ids.csv --ait

where --ait stands for --artist-in-title
so that a track title becomes "HNTR - Victory" instead of "Victory" where "HNTR" is the Artist

this is a matter of preference in how the tracks are visualized, but useful in listing tracks with only their title