### PR TITLE
Remux audio-only downloads to standard .m4a for hardware-player compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All downloaded files will be saved as MP3 in a folder named after your input fil
 * `create_db_with_youtube_ids.py` takes a CSV file with song data from Exportify as input and creates a new CSV containing:
     * For each song, we store "Track Name", "Artist Name(s)", "Duration (ms)", as well as a likely corresponding "Youtube ID".
 * `download_tracks.py` takes the CSV created by the previous step as input and downloads the songs from the matched youtube video.
+    * Audio-only downloads are losslessly remuxed from YouTube's fragmented DASH MP4 into a standard `.m4a` container, so the files also load on hardware players (DJ decks, car stereos) that reject fragmented MP4s.
     * After the download, the `Title` and `Contributing Artists` are set into the file's metadata tags.
 * `convert_tracks_to_mp3.py` converts all audio files in a directory to MP3 format (128kbps by default), preserving metadata. Use:
     * `poetry run python convert_tracks_to_mp3.py <download_folder> [-d]`

--- a/convert_tracks_to_mp3.py
+++ b/convert_tracks_to_mp3.py
@@ -14,6 +14,7 @@ from src.file_metadata import (
     extract_metadata_from_file,
     prepare_metadata_tags,
     set_file_metadata_tags,
+    FILE_EXTENSION_M4A,
     FILE_EXTENSION_MP3,
     FILE_EXTENSION_MP4,
 )
@@ -46,7 +47,7 @@ def convert_to_mp3(input_path, output_path, bitrate="128k"):
 
     ext = os.path.splitext(input_path)[1].lower()
     try:
-        if ext == FILE_EXTENSION_MP4:
+        if ext in (FILE_EXTENSION_MP4, FILE_EXTENSION_M4A):
             metadata = extract_metadata_from_file(input_path)
             music_df_row = {
                 "Artist Name(s)": metadata.get("artist", ""),
@@ -91,7 +92,11 @@ def main():
     bitrate = args.bitrate
     delete_originals = args.delete_originals
     print(f"Scanning directory: {directory}")
-    audio_files = list(scan_directory_for_audio_files(directory, {FILE_EXTENSION_MP4}))
+    audio_files = list(
+        scan_directory_for_audio_files(
+            directory, {FILE_EXTENSION_MP4, FILE_EXTENSION_M4A}
+        )
+    )
     print(f"Found {len(audio_files)} non-MP3 audio files.")
     for filepath in tqdm(audio_files):
         song_filename = os.path.basename(filepath)

--- a/create_db_from_directory.py
+++ b/create_db_from_directory.py
@@ -24,7 +24,12 @@ from src.youtube_id_search import (
     find_best_matching_youtube_id,
     get_youtube_search_results,
 )
-from src.file_metadata import extract_metadata_from_file, FILE_EXTENSION_MP3, FILE_EXTENSION_MP4
+from src.file_metadata import (
+    extract_metadata_from_file,
+    FILE_EXTENSION_M4A,
+    FILE_EXTENSION_MP3,
+    FILE_EXTENSION_MP4,
+)
 
 
 def get_output_filename(directory: str) -> str:
@@ -48,7 +53,7 @@ def main():
         sys.exit(1)
     directory = args.directory
     print(f"Scanning directory: {directory}")
-    extensions = {FILE_EXTENSION_MP3, FILE_EXTENSION_MP4}
+    extensions = {FILE_EXTENSION_MP3, FILE_EXTENSION_MP4, FILE_EXTENSION_M4A}
     audio_files = list(scan_directory_for_audio_files(directory, extensions))
     print(f"Found {len(audio_files)} audio files.")
     rows = []

--- a/src/file_metadata.py
+++ b/src/file_metadata.py
@@ -16,8 +16,9 @@ from src.data_handling import (
 
 FILE_EXTENSION_MP3 = ".mp3"
 FILE_EXTENSION_MP4 = ".mp4"
+FILE_EXTENSION_M4A = ".m4a"
 
-SUPPORTED_FORMATS = {FILE_EXTENSION_MP3, FILE_EXTENSION_MP4}
+SUPPORTED_FORMATS = {FILE_EXTENSION_MP3, FILE_EXTENSION_MP4, FILE_EXTENSION_M4A}
 
 METADATA_TAGS = {
     FILE_EXTENSION_MP3: {
@@ -38,6 +39,10 @@ METADATA_CLASSES = {
     FILE_EXTENSION_MP3: EasyID3,
     FILE_EXTENSION_MP4: MP4,
 }
+
+# .m4a files are MP4 containers, so they share the MP4 tag mapping and handler
+METADATA_TAGS[FILE_EXTENSION_M4A] = METADATA_TAGS[FILE_EXTENSION_MP4]
+METADATA_CLASSES[FILE_EXTENSION_M4A] = METADATA_CLASSES[FILE_EXTENSION_MP4]
 
 
 def extract_metadata_from_file(filepath: str) -> dict:
@@ -64,7 +69,7 @@ def extract_metadata_from_file(filepath: str) -> dict:
             # Bit rate in kbps
             if hasattr(audio_mp3.info, "bitrate"):
                 metadata["bit_rate"] = str(int(audio_mp3.info.bitrate // 1000))
-        elif ext == FILE_EXTENSION_MP4:
+        elif ext in (FILE_EXTENSION_MP4, FILE_EXTENSION_M4A):
             audio = MP4(filepath)
             metadata["artist"] = audio.tags.get("©ART", [""])[0]
             metadata["title"] = audio.tags.get("©nam", [""])[0]
@@ -91,7 +96,7 @@ def prepare_metadata_tags(
 
     metadata_tags = {}
 
-    if file_extension == FILE_EXTENSION_MP4:
+    if file_extension in (FILE_EXTENSION_MP4, FILE_EXTENSION_M4A):
         artist_names = music_df_row[COLUMN_ARTIST_NAME].replace(", ", "/")
     else:
         artist_names = music_df_row[COLUMN_ARTIST_NAME].split(",")

--- a/src/youtube_download.py
+++ b/src/youtube_download.py
@@ -1,11 +1,16 @@
 """Module for handling youtube download"""
 import os
+import subprocess
 
 from moviepy.video.io.ffmpeg_reader import ffmpeg_parse_infos
 from moviepy.video.io.VideoFileClip import VideoFileClip
 from pytubefix import YouTube
 
-from src.file_metadata import FILE_EXTENSION_MP3, FILE_EXTENSION_MP4
+from src.file_metadata import (
+    FILE_EXTENSION_M4A,
+    FILE_EXTENSION_MP3,
+    FILE_EXTENSION_MP4,
+)
 
 NUM_RETRIES = 5
 
@@ -20,7 +25,7 @@ def get_audio_from_youtube(youtube_url: str, output_dir: str, filename: str) -> 
     mp4_filepath = _download_mp4_video_from_youtube(youtube_url, output_dir, filename)
 
     if _is_mp4_file_audio_only(mp4_filepath):
-        return mp4_filepath
+        return _remux_to_clean_m4a(mp4_filepath)
 
     # If mp4 file contains video, we have to extract the audio track
     video_processing_failed = False
@@ -37,8 +42,8 @@ def get_audio_from_youtube(youtube_url: str, output_dir: str, filename: str) -> 
     # the default approach because this can lead to corrupted downloaded files, so we only use
     # it as a fallback.
     if video_processing_failed:
-        audio_filepath = _download_mp4_audio_from_youtube(
-            youtube_url, output_dir, filename
+        audio_filepath = _remux_to_clean_m4a(
+            _download_mp4_audio_from_youtube(youtube_url, output_dir, filename)
         )
 
     return audio_filepath
@@ -101,3 +106,55 @@ def _extract_audio_from_mp4_video(video_filepath: str) -> str:
 def _is_mp4_file_audio_only(mp4_filepath: str) -> bool:
     """This function checks whether an mp4 file is audio only."""
     return not ffmpeg_parse_infos(mp4_filepath)["video_found"]
+
+
+def _remux_to_clean_m4a(mp4_filepath: str) -> str:
+    """Remux a downloaded audio-only MP4 into a standard .m4a container.
+
+    YouTube serves audio-only streams as fragmented DASH MP4 (a `sidx` index
+    followed by many `moof`/`mdat` fragment pairs), and pytubefix saves that
+    stream to disk verbatim. Desktop software plays these files fine, but
+    hardware decoders (DJ players such as Pioneer/AlphaTheta CDJ/XDJ, some car
+    stereos) expect a standard progressive MP4 with a single `moov` index and
+    reject the fragmented files with "unsupported file format" errors.
+
+    Remuxing with ffmpeg (`-c copy`) rewrites only the container: the AAC audio
+    stream is copied bit-for-bit, so the operation is lossless and takes well
+    under a second per file.
+    """
+    m4a_filepath = os.path.splitext(mp4_filepath)[0] + FILE_EXTENSION_M4A
+    subprocess.run(
+        [
+            _get_ffmpeg_exe(),
+            "-v",
+            "error",
+            "-y",
+            "-i",
+            mp4_filepath,
+            "-map",
+            "0:a:0",
+            "-c",
+            "copy",
+            "-movflags",
+            "+faststart",
+            m4a_filepath,
+        ],
+        check=True,
+    )
+    os.remove(mp4_filepath)
+    return m4a_filepath
+
+
+def _get_ffmpeg_exe() -> str:
+    """Return the ffmpeg executable to use.
+
+    Prefer the binary bundled with moviepy's imageio-ffmpeg dependency, so the
+    remux works even without a system-wide ffmpeg installation; fall back to
+    ffmpeg on PATH.
+    """
+    try:
+        import imageio_ffmpeg
+
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception:
+        return "ffmpeg"


### PR DESCRIPTION
pytubefix saves YouTube's audio-only streams to disk verbatim, and YouTube serves those as fragmented DASH MP4 (a sidx index followed by many moof/mdat fragment pairs, major_brand "dash"). Desktop software decodes these fine, but hardware decoders - DJ players like Pioneer/AlphaTheta CDJ/XDJ, some car stereos - expect a standard progressive MP4 and reject every such file with "unsupported file format" errors.

Fix: after download, remux the file with ffmpeg (-c copy -movflags +faststart) into a standard .m4a container. The AAC stream is copied bit-for-bit (verified: decoded-audio MD5 identical before/after), so the operation is lossless and takes under a second per file. The bundled imageio-ffmpeg binary (already a moviepy dependency) is used when available, falling back to ffmpeg on PATH.

Also register .m4a as a supported extension so metadata tagging, the skip-already-downloaded check, directory scanning and MP3 conversion all handle the new output files (an .m4a is an MP4 container, so it shares the MP4 tag mapping).


Claude-Session: https://claude.ai/code/session_014UYZxns4752SWXNjyjmUyP