### PR TITLE
Feature/hardware compat checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ All downloaded files will be saved as MP3 in a folder named after your input fil
 * `convert_tracks_to_mp3.py` converts all audio files in a directory to MP3 format (128kbps by default), preserving metadata. Use:
     * `poetry run python convert_tracks_to_mp3.py <download_folder> [-d]`
     * The `-d` flag deletes original files after conversion.
+* `check_hardware_compat.py` checks audio files for compatibility with hardware DJ players (Pioneer/AlphaTheta CDJ/XDJ and similar) and reports a fix for each problem it finds — fragmented MP4 downloads, unsupported codecs (HE-AAC, Opus, ALAC), out-of-range sample rates, and WAV header traps. Use:
+    * `poetry run python check_hardware_compat.py <file_or_folder>` (add `--all` to also list passing files)
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -20,6 +20,8 @@ import streamlit as st
 import tidalapi
 from pytubefix.exceptions import BotDetection
 
+from check_hardware_compat import FAIL as HARDWARE_COMPAT_FAIL
+from check_hardware_compat import check_file as check_hardware_compat
 from convert_tracks_to_mp3 import convert_to_mp3
 from src.csv_handling import read_csv, write_csv
 from src.data_handling import (
@@ -101,6 +103,10 @@ STATE_FAILED_CONVERTING = "Failed converting"
 MAX_BOT_DETECTION_RETRIES = 3
 RETRY_BACKOFF_BASE_SECONDS = 5
 
+# Row key (not a CSV column - never added to display_columns) holding this
+# track's check_hardware_compat.py findings for the selected target device.
+ROW_KEY_HARDWARE_COMPAT_FINDINGS = "HardwareCompatFindings"
+
 # (r, g, b) tint per state: gray=not started, blue=matched, amber=in progress/transient,
 # green=success, red=terminal failure.
 STATE_COLORS = {
@@ -125,6 +131,10 @@ TRACK_CARD_STYLE = (
     ".track-artist { font-size: 0.85rem; opacity: 0.65; margin-left: 4px; }"
     ".track-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }"
     ".state-badge { font-size: 0.72rem; font-weight: 600; padding: 2px 9px; border-radius: 999px; white-space: nowrap; }"
+    ".compat-badge { font-size: 0.72rem; font-weight: 600; padding: 2px 9px; border-radius: 999px; "
+    "white-space: nowrap; cursor: help; }"
+    ".compat-badge.compat-warn { background-color: rgba(255,152,0,0.15); color: rgb(255,152,0); }"
+    ".compat-badge.compat-fail { background-color: rgba(244,67,54,0.15); color: rgb(244,67,54); }"
     ".yt-link, .yt-link-disabled, .sc-link { display: inline-block; font-size: 0.78rem; font-weight: 600; "
     "padding: 6px 14px; border-radius: 6px; text-decoration: none; white-space: nowrap; border: none; }"
     ".yt-link { background-color: #FF0000; color: white; box-shadow: 0 1px 2px rgba(0,0,0,0.25); cursor: pointer; }"
@@ -348,6 +358,18 @@ def _build_track_state_badge_html(row: dict) -> str:
     )
 
 
+def _build_hardware_compat_badge_html(row: dict) -> str:
+    findings = row.get(ROW_KEY_HARDWARE_COMPAT_FINDINGS)
+    if not findings:
+        return ""
+    worst_fail = any(level == HARDWARE_COMPAT_FAIL for level, _ in findings)
+    css_class = "compat-fail" if worst_fail else "compat-warn"
+    icon = "⛔" if worst_fail else "⚠"
+    tooltip = html.escape(" | ".join(f"{level}: {message}" for level, message in findings))
+    count = len(findings)
+    return f'<span class="compat-badge {css_class}" title="{tooltip}">{icon} {count}</span>'
+
+
 def _build_track_bottom_html(row: dict) -> str:
     annotation_parts = []
     duration_str = _format_duration(row.get(COLUMN_TRACK_DURATION))
@@ -390,7 +412,8 @@ def build_track_card_html(row: dict) -> str:
         '<div class="track-card-top">'
         f'<div><span class="track-title">{track_name}</span>'
         f'<span class="track-artist">{artist_name}</span></div>'
-        f'<div class="track-actions">{_build_track_state_badge_html(row)}{yt_element}</div>'
+        f'<div class="track-actions">{_build_track_state_badge_html(row)}'
+        f"{_build_hardware_compat_badge_html(row)}{yt_element}</div>"
         "</div>" + _build_track_bottom_html(row) + "</div>"
     )
 
@@ -782,10 +805,11 @@ with options_col:
         "Target device",
         ["Custom"] + list(DEVICE_PROFILES.keys()),
         index=0,
-        help="Picks quality settings to match what the device actually supports. "
-        "Output is MP3-only for now, so only the bitrate ceiling applies today.",
+        help="Caps the MP3 bitrate at what the device supports, and flags each "
+        "downloaded track with hardware-compatibility warnings for that device.",
     )
     if target_device == "Custom":
+        device_profile = None
         bitrate_checkbox_col, bitrate_select_col = st.columns([2, 3], vertical_alignment="center")
         with bitrate_checkbox_col:
             use_max_bitrate = st.checkbox("Max available bitrate", value=True)
@@ -809,7 +833,8 @@ with options_col:
         )
         st.caption(
             f"Supports {supported_formats} · MP3 capped at {device_profile.max_mp3_kbps}kbps · "
-            f"sample rate {sample_rate_note} (not yet enforced — MP3-only output for now)"
+            f"sample rate {sample_rate_note} (output is still MP3-only — tracks that would "
+            f"need another format to fit this device show up as warnings after download)"
         )
     artist_col, delete_col = st.columns(2)
     with artist_col:
@@ -990,6 +1015,16 @@ def _maybe_downsample_mp3(filepath: str, row: dict) -> None:
         row[COLUMN_BIT_RATE] = get_file_bit_rate_kbps(filepath)
 
 
+def _run_hardware_compat_check(row: dict, filepath: str) -> None:
+    """Check the final output file against the selected target device (or the
+    generic device-agnostic warnings, if "Custom" is selected) and stash the
+    findings on the row for the track card to display."""
+    try:
+        row[ROW_KEY_HARDWARE_COMPAT_FINDINGS] = check_hardware_compat(filepath, device_profile=device_profile)
+    except Exception as exc:
+        print(f"Hardware-compat check failed for '{filepath}': {exc}")
+
+
 def run_download_stage(download_dir):
     pending_rows = [row for row in st.session_state.tracks if row["State"] == STATE_MATCHED]
     total = len(pending_rows)
@@ -1022,10 +1057,11 @@ def run_download_stage(download_dir):
                 # A SoundCloud download already lands as mp3 (no conversion needed);
                 # a YouTube one lands as mp4 and still needs the conversion stage.
                 row["State"] = STATE_CONVERTED if existing_ext == FILE_EXTENSION_MP3 else STATE_DOWNLOADED
+                existing_filepath = os.path.join(download_dir, song_filename + existing_ext)
                 if not row.get(COLUMN_BIT_RATE):
-                    row[COLUMN_BIT_RATE] = get_file_bit_rate_kbps(
-                        os.path.join(download_dir, song_filename + existing_ext)
-                    )
+                    row[COLUMN_BIT_RATE] = get_file_bit_rate_kbps(existing_filepath)
+                if existing_ext == FILE_EXTENSION_MP3 and ROW_KEY_HARDWARE_COMPAT_FINDINGS not in row:
+                    _run_hardware_compat_check(row, existing_filepath)
             else:
                 try:
                     output_filepath = _download_track_audio(row, download_dir, song_filename)
@@ -1046,6 +1082,7 @@ def run_download_stage(download_dir):
                     set_file_metadata_tags(filepath=output_filepath, metadata_tags=metadata_tags)
                     if file_extension == FILE_EXTENSION_MP3:
                         _maybe_downsample_mp3(output_filepath, row)
+                        _run_hardware_compat_check(row, output_filepath)
                 except BotDetection:
                     row["State"] = STATE_FAILED_BEFORE_RETRY
                     still_pending.append(row)
@@ -1086,6 +1123,8 @@ def run_conversion_stage(download_dir):
                 row["State"] = STATE_CONVERTED
                 if not row.get(COLUMN_BIT_RATE):
                     row[COLUMN_BIT_RATE] = get_file_bit_rate_kbps(mp3_path)
+                if ROW_KEY_HARDWARE_COMPAT_FINDINGS not in row:
+                    _run_hardware_compat_check(row, mp3_path)
         else:
             if row is not None:
                 row["State"] = STATE_CONVERTING
@@ -1096,6 +1135,7 @@ def run_conversion_stage(download_dir):
                 row["State"] = STATE_CONVERTED if success else STATE_FAILED_CONVERTING
                 if success:
                     row[COLUMN_BIT_RATE] = get_file_bit_rate_kbps(mp3_path)
+                    _run_hardware_compat_check(row, mp3_path)
             if success and delete_originals:
                 os.remove(filepath)
 

--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ from src.data_handling import (
     get_youtube_url,
     sanitize_filename,
 )
+from src.device_profiles import DEVICE_PROFILES
 from src.file_handling import scan_directory_for_audio_files
 from src.file_metadata import (
     FILE_EXTENSION_MP3,
@@ -777,16 +778,38 @@ def render_unmatched_tracks_panel():
 
 options_col, steps_col = st.columns([1, 3])
 with options_col:
-    bitrate_checkbox_col, bitrate_select_col = st.columns([2, 3], vertical_alignment="center")
-    with bitrate_checkbox_col:
-        use_max_bitrate = st.checkbox("Max available bitrate", value=True)
-    with bitrate_select_col:
-        bitrate = st.selectbox(
-            "MP3 bitrate",
-            ["128k", "192k", "256k", "320k"],
-            index=0,
-            label_visibility="collapsed",
-            disabled=use_max_bitrate,
+    target_device = st.selectbox(
+        "Target device",
+        ["Custom"] + list(DEVICE_PROFILES.keys()),
+        index=0,
+        help="Picks quality settings to match what the device actually supports. "
+        "Output is MP3-only for now, so only the bitrate ceiling applies today.",
+    )
+    if target_device == "Custom":
+        bitrate_checkbox_col, bitrate_select_col = st.columns([2, 3], vertical_alignment="center")
+        with bitrate_checkbox_col:
+            use_max_bitrate = st.checkbox("Max available bitrate", value=True)
+        with bitrate_select_col:
+            bitrate = st.selectbox(
+                "MP3 bitrate",
+                ["128k", "192k", "256k", "320k"],
+                index=0,
+                label_visibility="collapsed",
+                disabled=use_max_bitrate,
+            )
+    else:
+        device_profile = DEVICE_PROFILES[target_device]
+        use_max_bitrate = True
+        bitrate = f"{device_profile.max_mp3_kbps}k"
+        supported_formats = ", ".join(fmt.upper() for fmt in device_profile.formats)
+        sample_rate_note = (
+            f"up to {device_profile.max_sample_rate_hz // 1000}kHz"
+            if device_profile.max_sample_rate_hz
+            else "no device ceiling"
+        )
+        st.caption(
+            f"Supports {supported_formats} · MP3 capped at {device_profile.max_mp3_kbps}kbps · "
+            f"sample rate {sample_rate_note} (not yet enforced — MP3-only output for now)"
         )
     artist_col, delete_col = st.columns(2)
     with artist_col:

--- a/check_hardware_compat.py
+++ b/check_hardware_compat.py
@@ -29,6 +29,8 @@ import struct
 import subprocess
 import sys
 
+from src.device_profiles import DEVICE_PROFILES
+
 AUDIO_EXTENSIONS = {
     ".mp3",
     ".mp4",
@@ -45,10 +47,25 @@ AUDIO_EXTENSIONS = {
     ".webm",
 }
 
+_DEVICE_SAMPLE_RATE_CEILINGS = [
+    profile.max_sample_rate_hz
+    for profile in DEVICE_PROFILES.values()
+    if profile.max_sample_rate_hz is not None
+]
+_STANDARD_SAMPLE_RATES = (44100, 48000, 88200, 96000)
+
 # Sample rates in the guaranteed envelope of every Pioneer/AlphaTheta player
-SAFE_SAMPLE_RATES = {44100, 48000}
-# Accepted for lossless formats by newer players only (CDJ-3000, NXS2, XDJ-AZ)
-HIRES_SAMPLE_RATES = {88200, 96000}
+# (i.e. within even the legacy CDJ-2000/CDJ-900 ceiling in DEVICE_PROFILES).
+SAFE_SAMPLE_RATES = {
+    rate for rate in _STANDARD_SAMPLE_RATES if rate <= min(_DEVICE_SAMPLE_RATE_CEILINGS)
+}
+# Accepted for lossless formats by newer players only (CDJ-3000, NXS2, XDJ-AZ) -
+# above the legacy ceiling but within the highest ceiling in DEVICE_PROFILES.
+HIRES_SAMPLE_RATES = {
+    rate
+    for rate in _STANDARD_SAMPLE_RATES
+    if min(_DEVICE_SAMPLE_RATE_CEILINGS) < rate <= max(_DEVICE_SAMPLE_RATE_CEILINGS)
+}
 
 FAIL = "FAIL"
 WARN = "WARN"

--- a/check_hardware_compat.py
+++ b/check_hardware_compat.py
@@ -29,7 +29,7 @@ import struct
 import subprocess
 import sys
 
-from src.device_profiles import DEVICE_PROFILES
+from src.device_profiles import DEVICE_PROFILES, DeviceProfile
 
 AUDIO_EXTENSIONS = {
     ".mp3",
@@ -69,6 +69,33 @@ HIRES_SAMPLE_RATES = {
 
 FAIL = "FAIL"
 WARN = "WARN"
+
+
+def _sample_rate_finding(
+    sample_rate: int, *, lossless: bool, device_profile: DeviceProfile | None
+) -> tuple[str, str] | None:
+    """Decide the finding for one sample rate, given the file's format
+    (lossless or not) and which device (if any) it's being checked against."""
+    if sample_rate in SAFE_SAMPLE_RATES:
+        return None
+    if lossless and sample_rate in HIRES_SAMPLE_RATES:
+        if device_profile is None:
+            return (WARN, f"{sample_rate} Hz - only 2016+ players accept it; older gear caps at 48 kHz")
+        if device_profile.max_sample_rate_hz and sample_rate <= device_profile.max_sample_rate_hz:
+            return None
+        return (FAIL, f"{sample_rate} Hz exceeds {device_profile.name}'s sample-rate ceiling")
+    return (FAIL, f"{sample_rate} Hz sample rate is outside every player's range")
+
+
+def _format_support_finding(
+    container_format: str, label: str, device_profile: DeviceProfile | None
+) -> tuple[str, str] | None:
+    """Decide the finding for a format (FLAC/ALAC) that only some devices support."""
+    if device_profile is None:
+        return (WARN, f"{label} only plays on 2016+ players (XDJ-1000MK2, NXS2, CDJ-3000, XDJ-AZ)")
+    if container_format in device_profile.formats:
+        return None
+    return (FAIL, f"{label} is not supported on {device_profile.name}")
 
 
 def _ffprobe(filepath: str) -> dict | None:
@@ -114,7 +141,9 @@ def _scan_mp4_boxes(filepath: str) -> list[str]:
     return boxes
 
 
-def _check_mp4(filepath: str, probe: dict) -> list[tuple[str, str]]:
+def _check_mp4(
+    filepath: str, probe: dict, device_profile: DeviceProfile | None = None
+) -> list[tuple[str, str]]:
     """Check .mp4/.m4a files: container structure and codec."""
     findings = []
 
@@ -162,23 +191,19 @@ def _check_mp4(filepath: str, probe: dict) -> list[tuple[str, str]]:
                 (FAIL, f"AAC profile is {profile} - players decode AAC-LC only. Re-encode.")
             )
     elif codec == "alac":
-        findings.append(
-            (
-                WARN,
-                "ALAC - plays on 2016+ players (XDJ-1000MK2, NXS2, CDJ-3000, XDJ-AZ) "
-                "but fails on older gear (CDJ-850/900/2000, XDJ-1000 mk1)",
-            )
-        )
+        finding = _format_support_finding("alac", "ALAC", device_profile)
+        if finding:
+            findings.append(finding)
     elif codec in ("opus", "vorbis"):
         findings.append((FAIL, f"{codec} audio in MP4 - no hardware player supports it. Re-encode to AAC-LC."))
     else:
         findings.append((FAIL, f"unexpected codec '{codec}' in MP4 container"))
 
-    findings.extend(_check_rate_and_channels(audio, lossless=False))
+    findings.extend(_check_rate_and_channels(audio, lossless=False, device_profile=device_profile))
     return findings
 
 
-def _check_wav(filepath: str) -> list[tuple[str, str]]:
+def _check_wav(filepath: str, device_profile: DeviceProfile | None = None) -> list[tuple[str, str]]:
     """Check WAV files by parsing the RIFF fmt chunk directly.
 
     ffprobe's codec label hides the difference between plain PCM and
@@ -232,20 +257,18 @@ def _check_wav(filepath: str) -> list[tuple[str, str]]:
         )
     if channels > 2:
         findings.append((FAIL, f"{channels} channels - downmix to stereo"))
-    if sample_rate not in SAFE_SAMPLE_RATES:
-        if sample_rate in HIRES_SAMPLE_RATES:
-            findings.append(
-                (WARN, f"{sample_rate} Hz - only 2016+ players accept it; older gear caps at 48 kHz")
-            )
-        else:
-            findings.append((FAIL, f"{sample_rate} Hz sample rate is outside every player's range"))
+    finding = _sample_rate_finding(sample_rate, lossless=True, device_profile=device_profile)
+    if finding:
+        findings.append(finding)
 
     if os.path.getsize(filepath) > 4 * 1024**3:
         findings.append((FAIL, "file exceeds the FAT32 4 GB limit"))
     return findings
 
 
-def _check_mp3(filepath: str, probe: dict) -> list[tuple[str, str]]:
+def _check_mp3(
+    filepath: str, probe: dict, device_profile: DeviceProfile | None = None
+) -> list[tuple[str, str]]:
     findings = []
     audio = next((s for s in probe["streams"] if s["codec_type"] == "audio"), None)
     if audio is None:
@@ -259,7 +282,7 @@ def _check_mp3(filepath: str, probe: dict) -> list[tuple[str, str]]:
             )
         )
         return findings
-    findings.extend(_check_rate_and_channels(audio, lossless=False))
+    findings.extend(_check_rate_and_channels(audio, lossless=False, device_profile=device_profile))
     # Oversized ID3v2 tags have been linked to load failures on CDJs
     with open(filepath, "rb") as file:
         head = file.read(10)
@@ -272,7 +295,9 @@ def _check_mp3(filepath: str, probe: dict) -> list[tuple[str, str]]:
     return findings
 
 
-def _check_flac(filepath: str, probe: dict) -> list[tuple[str, str]]:
+def _check_flac(
+    filepath: str, probe: dict, device_profile: DeviceProfile | None = None
+) -> list[tuple[str, str]]:
     findings = []
     with open(filepath, "rb") as file:
         magic = file.read(4)
@@ -284,17 +309,19 @@ def _check_flac(filepath: str, probe: dict) -> list[tuple[str, str]]:
         findings.append((FAIL, "not a native FLAC file despite the extension"))
     audio = next((s for s in probe["streams"] if s["codec_type"] == "audio"), None)
     if audio:
-        findings.extend(_check_rate_and_channels(audio, lossless=True))
+        findings.extend(_check_rate_and_channels(audio, lossless=True, device_profile=device_profile))
         bits = int(audio.get("bits_per_raw_sample") or audio.get("bits_per_sample") or 16)
         if bits > 24:
             findings.append((FAIL, f"{bits}-bit FLAC - players support up to 24-bit"))
-    findings.append(
-        (WARN, "FLAC only plays on 2016+ players (XDJ-1000MK2, NXS2, CDJ-3000, XDJ-AZ)")
-    )
+    finding = _format_support_finding("flac", "FLAC", device_profile)
+    if finding:
+        findings.append(finding)
     return findings
 
 
-def _check_aiff(filepath: str, probe: dict) -> list[tuple[str, str]]:
+def _check_aiff(
+    filepath: str, probe: dict, device_profile: DeviceProfile | None = None
+) -> list[tuple[str, str]]:
     findings = []
     audio = next((s for s in probe["streams"] if s["codec_type"] == "audio"), None)
     if audio is None:
@@ -307,29 +334,32 @@ def _check_aiff(filepath: str, probe: dict) -> list[tuple[str, str]]:
         findings.append(
             (WARN, "'.aifc' extension is rejected even when uncompressed - rename to .aiff")
         )
-    findings.extend(_check_rate_and_channels(audio, lossless=True))
+    findings.extend(_check_rate_and_channels(audio, lossless=True, device_profile=device_profile))
     return findings
 
 
-def _check_rate_and_channels(audio: dict, lossless: bool) -> list[tuple[str, str]]:
+def _check_rate_and_channels(
+    audio: dict, lossless: bool, device_profile: DeviceProfile | None = None
+) -> list[tuple[str, str]]:
     findings = []
     sample_rate = int(audio.get("sample_rate") or 0)
-    if sample_rate not in SAFE_SAMPLE_RATES:
-        if lossless and sample_rate in HIRES_SAMPLE_RATES:
-            findings.append(
-                (WARN, f"{sample_rate} Hz - only 2016+ players accept it; older gear caps at 48 kHz")
-            )
-        else:
-            findings.append(
-                (FAIL, f"{sample_rate} Hz sample rate - players require 44.1/48 kHz. Resample.")
-            )
+    finding = _sample_rate_finding(sample_rate, lossless=lossless, device_profile=device_profile)
+    if finding:
+        findings.append(finding)
     if int(audio.get("channels") or 0) > 2:
         findings.append((FAIL, f"{audio.get('channels')} channels - downmix to stereo"))
     return findings
 
 
-def check_file(filepath: str) -> list[tuple[str, str]]:
-    """Run the appropriate checks for one file and return (level, message) findings."""
+def check_file(filepath: str, device_profile: DeviceProfile | None = None) -> list[tuple[str, str]]:
+    """Run the appropriate checks for one file and return (level, message) findings.
+
+    When device_profile is given, findings are tailored to that specific
+    device (e.g. a hi-res sample rate that would only WARN in general becomes
+    a FAIL if the device's ceiling is lower, or no finding at all if it's
+    within range). Without one, checks fall back to generic warnings that
+    cover the whole range of hardware players in DEVICE_PROFILES.
+    """
     ext = os.path.splitext(filepath)[1].lower()
 
     if ext in (".ogg", ".opus", ".webm"):
@@ -338,26 +368,28 @@ def check_file(filepath: str) -> list[tuple[str, str]]:
         return [(FAIL, "DRM-protected iTunes file - cannot be fixed, re-source the track")]
 
     if ext == ".wav":
-        return _check_wav(filepath)
+        return _check_wav(filepath, device_profile=device_profile)
 
     probe = _ffprobe(filepath)
     if probe is None:
         return [(FAIL, "ffprobe cannot parse this file - it is corrupt or not audio")]
 
     if ext in (".mp4", ".m4a"):
-        return _check_mp4(filepath, probe)
+        return _check_mp4(filepath, probe, device_profile=device_profile)
     if ext == ".aac":
-        return _check_adts(filepath, probe)
+        return _check_adts(filepath, probe, device_profile=device_profile)
     if ext == ".mp3":
-        return _check_mp3(filepath, probe)
+        return _check_mp3(filepath, probe, device_profile=device_profile)
     if ext == ".flac":
-        return _check_flac(filepath, probe)
+        return _check_flac(filepath, probe, device_profile=device_profile)
     if ext in (".aif", ".aiff", ".aifc"):
-        return _check_aiff(filepath, probe)
+        return _check_aiff(filepath, probe, device_profile=device_profile)
     return []
 
 
-def _check_adts(filepath: str, probe: dict) -> list[tuple[str, str]]:
+def _check_adts(
+    filepath: str, probe: dict, device_profile: DeviceProfile | None = None
+) -> list[tuple[str, str]]:
     """Check raw .aac (ADTS) files."""
     findings = []
     audio = next((s for s in probe["streams"] if s["codec_type"] == "audio"), None)
@@ -370,7 +402,7 @@ def _check_adts(filepath: str, probe: dict) -> list[tuple[str, str]]:
         (WARN, "raw ADTS .aac streams are unreliable on players - remux into .m4a: "
                "ffmpeg -i in -c copy -bsf:a aac_adtstoasc out.m4a")
     )
-    findings.extend(_check_rate_and_channels(audio, lossless=False))
+    findings.extend(_check_rate_and_channels(audio, lossless=False, device_profile=device_profile))
     return findings
 
 
@@ -393,6 +425,13 @@ def main():
     parser.add_argument(
         "--all", action="store_true", help="Also list files that pass every check"
     )
+    parser.add_argument(
+        "--device",
+        choices=list(DEVICE_PROFILES.keys()),
+        default=None,
+        help="Check against one specific device instead of the generic warnings "
+        "that cover every player in DEVICE_PROFILES",
+    )
     args = parser.parse_args()
 
     if shutil.which("ffprobe") is None:
@@ -404,9 +443,11 @@ def main():
         print("No audio files found.")
         sys.exit(0)
 
+    device_profile = DEVICE_PROFILES[args.device] if args.device else None
+
     counts = {FAIL: 0, WARN: 0, "OK": 0}
     for filepath in files:
-        findings = check_file(filepath)
+        findings = check_file(filepath, device_profile=device_profile)
         worst = FAIL if any(l == FAIL for l, _ in findings) else (
             WARN if findings else "OK"
         )

--- a/check_hardware_compat.py
+++ b/check_hardware_compat.py
@@ -1,0 +1,411 @@
+"""
+Script to check audio files for compatibility with hardware DJ players
+(Pioneer/AlphaTheta CDJ/XDJ and similar embedded decoders).
+
+Desktop software uses lenient decoders and will happily play files that
+hardware players reject with "unsupported file format" errors (E-8305 family).
+This script detects the known file-level causes before the files reach a
+player:
+
+  * fragmented DASH MP4 containers (YouTube downloads)      -> remux
+  * wrong codec inside the container (HE-AAC, Opus, ALAC)   -> re-encode
+  * WAV traps: 32-bit/float samples, WAVE_FORMAT_EXTENSIBLE -> convert
+  * out-of-range sample rates (22.05 kHz, > 48 kHz)         -> resample
+  * formats with no hardware support at all (.ogg/.opus)    -> re-encode
+  * mislabeled files (extension does not match the content)
+
+Usage:
+    poetry run python check_hardware_compat.py <file_or_directory> [--all]
+
+Exit code is 0 when every scanned file passes, 1 when any file FAILs.
+Requires ffprobe (installed together with ffmpeg).
+"""
+
+import argparse
+import json
+import os
+import shutil
+import struct
+import subprocess
+import sys
+
+AUDIO_EXTENSIONS = {
+    ".mp3",
+    ".mp4",
+    ".m4a",
+    ".m4p",
+    ".aac",
+    ".wav",
+    ".aif",
+    ".aiff",
+    ".aifc",
+    ".flac",
+    ".ogg",
+    ".opus",
+    ".webm",
+}
+
+# Sample rates in the guaranteed envelope of every Pioneer/AlphaTheta player
+SAFE_SAMPLE_RATES = {44100, 48000}
+# Accepted for lossless formats by newer players only (CDJ-3000, NXS2, XDJ-AZ)
+HIRES_SAMPLE_RATES = {88200, 96000}
+
+FAIL = "FAIL"
+WARN = "WARN"
+
+
+def _ffprobe(filepath: str) -> dict | None:
+    """Run ffprobe and return the parsed JSON, or None if the file cannot be parsed."""
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_format",
+            "-show_streams",
+            "-of",
+            "json",
+            filepath,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout)
+
+
+def _scan_mp4_boxes(filepath: str) -> list[str]:
+    """Return the top-level MP4 box names, e.g. ['ftyp', 'moov', 'mdat']."""
+    boxes = []
+    size = os.path.getsize(filepath)
+    pos = 0
+    with open(filepath, "rb") as file:
+        while pos < size - 8:
+            file.seek(pos)
+            header = file.read(8)
+            if len(header) < 8:
+                break
+            (box_size,) = struct.unpack(">I", header[:4])
+            name = header[4:8].decode("latin1")
+            if box_size == 1:  # 64-bit box size
+                (box_size,) = struct.unpack(">Q", file.read(8))
+            if box_size < 8:
+                break
+            boxes.append(name)
+            pos += box_size
+    return boxes
+
+
+def _check_mp4(filepath: str, probe: dict) -> list[tuple[str, str]]:
+    """Check .mp4/.m4a files: container structure and codec."""
+    findings = []
+
+    boxes = _scan_mp4_boxes(filepath)
+    if "moof" in boxes or "sidx" in boxes or "styp" in boxes:
+        findings.append(
+            (
+                FAIL,
+                "fragmented DASH MP4 container - hardware players cannot parse it. "
+                'Fix (lossless): ffmpeg -i in -c copy -movflags +faststart out.m4a',
+            )
+        )
+    if boxes.count("moov") > 1:
+        findings.append((FAIL, "multiple moov atoms - remux the file"))
+    if boxes and boxes[0] != "ftyp":
+        findings.append((WARN, "container does not start with an ftyp box"))
+
+    audio_streams = [s for s in probe["streams"] if s["codec_type"] == "audio"]
+    video_streams = [
+        s
+        for s in probe["streams"]
+        if s["codec_type"] == "video"
+        and not s.get("disposition", {}).get("attached_pic")
+    ]
+    if video_streams:
+        findings.append(
+            (
+                WARN,
+                f"contains a video track ({video_streams[0].get('codec_name')}) - "
+                "strip it: ffmpeg -i in -map 0:a:0 -c copy out.m4a",
+            )
+        )
+    if len(audio_streams) > 1:
+        findings.append((WARN, f"{len(audio_streams)} audio tracks - keep only the first"))
+    if not audio_streams:
+        findings.append((FAIL, "no audio track found"))
+        return findings
+
+    audio = audio_streams[0]
+    codec = audio.get("codec_name")
+    profile = audio.get("profile") or ""
+    if codec == "aac":
+        if "HE" in profile or "SBR" in profile:
+            findings.append(
+                (FAIL, f"AAC profile is {profile} - players decode AAC-LC only. Re-encode.")
+            )
+    elif codec == "alac":
+        findings.append(
+            (
+                WARN,
+                "ALAC - plays on 2016+ players (XDJ-1000MK2, NXS2, CDJ-3000, XDJ-AZ) "
+                "but fails on older gear (CDJ-850/900/2000, XDJ-1000 mk1)",
+            )
+        )
+    elif codec in ("opus", "vorbis"):
+        findings.append((FAIL, f"{codec} audio in MP4 - no hardware player supports it. Re-encode to AAC-LC."))
+    else:
+        findings.append((FAIL, f"unexpected codec '{codec}' in MP4 container"))
+
+    findings.extend(_check_rate_and_channels(audio, lossless=False))
+    return findings
+
+
+def _check_wav(filepath: str) -> list[tuple[str, str]]:
+    """Check WAV files by parsing the RIFF fmt chunk directly.
+
+    ffprobe's codec label hides the difference between plain PCM and
+    WAVE_FORMAT_EXTENSIBLE headers, and hardware players reject the latter,
+    so the header bytes are the only reliable source of truth here.
+    """
+    findings = []
+    with open(filepath, "rb") as file:
+        header = file.read(12)
+        if header[:4] != b"RIFF" or header[8:12] != b"WAVE":
+            return [(FAIL, "not a RIFF/WAVE file despite the .wav extension")]
+        # Walk chunks to find fmt
+        while True:
+            chunk_header = file.read(8)
+            if len(chunk_header) < 8:
+                return [(FAIL, "no fmt chunk found - corrupt WAV header")]
+            chunk_id = chunk_header[:4]
+            (chunk_size,) = struct.unpack("<I", chunk_header[4:])
+            if chunk_id == b"fmt ":
+                fmt = file.read(min(chunk_size, 40))
+                break
+            file.seek(chunk_size + (chunk_size & 1), os.SEEK_CUR)
+
+    format_tag, channels, sample_rate, _, _, bits = struct.unpack("<HHIIHH", fmt[:16])
+
+    if format_tag == 0xFFFE:  # WAVE_FORMAT_EXTENSIBLE
+        sub_format = fmt[24:26] if len(fmt) >= 26 else b""
+        if sub_format == b"\x01\x00":  # PCM sub-format GUID starts 01 00
+            findings.append(
+                (
+                    FAIL,
+                    "WAVE_FORMAT_EXTENSIBLE header (0xFFFE) - the audio is plain PCM "
+                    "but players reject the header (common with Bandcamp/DAW exports). "
+                    "Fix: rewrite header bytes 20-21 to 01 00, or re-export the file.",
+                )
+            )
+        elif sub_format == b"\x03\x00":
+            findings.append(
+                (FAIL, "32-bit float WAV (EXTENSIBLE) - no player supports it. Convert to 16/24-bit PCM.")
+            )
+        else:
+            findings.append((FAIL, "WAVE_FORMAT_EXTENSIBLE with a non-PCM sub-format"))
+    elif format_tag == 0x0003:
+        findings.append((FAIL, "32-bit float WAV - no player supports it. Convert to 16/24-bit PCM."))
+    elif format_tag != 0x0001:
+        findings.append((FAIL, f"non-PCM WAV format tag 0x{format_tag:04X}"))
+
+    if bits not in (16, 24):
+        findings.append(
+            (FAIL, f"{bits}-bit samples - players support 16/24-bit WAV only. Convert.")
+        )
+    if channels > 2:
+        findings.append((FAIL, f"{channels} channels - downmix to stereo"))
+    if sample_rate not in SAFE_SAMPLE_RATES:
+        if sample_rate in HIRES_SAMPLE_RATES:
+            findings.append(
+                (WARN, f"{sample_rate} Hz - only 2016+ players accept it; older gear caps at 48 kHz")
+            )
+        else:
+            findings.append((FAIL, f"{sample_rate} Hz sample rate is outside every player's range"))
+
+    if os.path.getsize(filepath) > 4 * 1024**3:
+        findings.append((FAIL, "file exceeds the FAT32 4 GB limit"))
+    return findings
+
+
+def _check_mp3(filepath: str, probe: dict) -> list[tuple[str, str]]:
+    findings = []
+    audio = next((s for s in probe["streams"] if s["codec_type"] == "audio"), None)
+    if audio is None:
+        return [(FAIL, "no audio stream found")]
+    if audio.get("codec_name") != "mp3":
+        findings.append(
+            (
+                FAIL,
+                f"content is {audio.get('codec_name')}, not MP3 - mislabeled file "
+                "(common with converter websites). Re-encode or fix the extension.",
+            )
+        )
+        return findings
+    findings.extend(_check_rate_and_channels(audio, lossless=False))
+    # Oversized ID3v2 tags have been linked to load failures on CDJs
+    with open(filepath, "rb") as file:
+        head = file.read(10)
+    if head[:3] == b"ID3":
+        tag_size = (head[6] << 21) | (head[7] << 14) | (head[8] << 7) | head[9]
+        if tag_size > 2 * 1024**2:
+            findings.append(
+                (WARN, f"very large ID3v2 tag ({tag_size // 1024} KiB) - strip oversized artwork/tags")
+            )
+    return findings
+
+
+def _check_flac(filepath: str, probe: dict) -> list[tuple[str, str]]:
+    findings = []
+    with open(filepath, "rb") as file:
+        magic = file.read(4)
+    if magic[:3] == b"ID3":
+        findings.append(
+            (FAIL, "ID3 tag prepended to FLAC - strict parsers reject it. Rewrite: ffmpeg -i in -c copy out.flac")
+        )
+    elif magic != b"fLaC":
+        findings.append((FAIL, "not a native FLAC file despite the extension"))
+    audio = next((s for s in probe["streams"] if s["codec_type"] == "audio"), None)
+    if audio:
+        findings.extend(_check_rate_and_channels(audio, lossless=True))
+        bits = int(audio.get("bits_per_raw_sample") or audio.get("bits_per_sample") or 16)
+        if bits > 24:
+            findings.append((FAIL, f"{bits}-bit FLAC - players support up to 24-bit"))
+    findings.append(
+        (WARN, "FLAC only plays on 2016+ players (XDJ-1000MK2, NXS2, CDJ-3000, XDJ-AZ)")
+    )
+    return findings
+
+
+def _check_aiff(filepath: str, probe: dict) -> list[tuple[str, str]]:
+    findings = []
+    audio = next((s for s in probe["streams"] if s["codec_type"] == "audio"), None)
+    if audio is None:
+        return [(FAIL, "no audio stream found")]
+    if audio.get("codec_name") not in ("pcm_s16be", "pcm_s24be"):
+        findings.append(
+            (FAIL, f"AIFF codec {audio.get('codec_name')} - only uncompressed 16/24-bit PCM plays")
+        )
+    if filepath.lower().endswith(".aifc"):
+        findings.append(
+            (WARN, "'.aifc' extension is rejected even when uncompressed - rename to .aiff")
+        )
+    findings.extend(_check_rate_and_channels(audio, lossless=True))
+    return findings
+
+
+def _check_rate_and_channels(audio: dict, lossless: bool) -> list[tuple[str, str]]:
+    findings = []
+    sample_rate = int(audio.get("sample_rate") or 0)
+    if sample_rate not in SAFE_SAMPLE_RATES:
+        if lossless and sample_rate in HIRES_SAMPLE_RATES:
+            findings.append(
+                (WARN, f"{sample_rate} Hz - only 2016+ players accept it; older gear caps at 48 kHz")
+            )
+        else:
+            findings.append(
+                (FAIL, f"{sample_rate} Hz sample rate - players require 44.1/48 kHz. Resample.")
+            )
+    if int(audio.get("channels") or 0) > 2:
+        findings.append((FAIL, f"{audio.get('channels')} channels - downmix to stereo"))
+    return findings
+
+
+def check_file(filepath: str) -> list[tuple[str, str]]:
+    """Run the appropriate checks for one file and return (level, message) findings."""
+    ext = os.path.splitext(filepath)[1].lower()
+
+    if ext in (".ogg", ".opus", ".webm"):
+        return [(FAIL, f"'{ext}' has no hardware player support at all - re-encode to AAC-LC or MP3")]
+    if ext == ".m4p":
+        return [(FAIL, "DRM-protected iTunes file - cannot be fixed, re-source the track")]
+
+    if ext == ".wav":
+        return _check_wav(filepath)
+
+    probe = _ffprobe(filepath)
+    if probe is None:
+        return [(FAIL, "ffprobe cannot parse this file - it is corrupt or not audio")]
+
+    if ext in (".mp4", ".m4a"):
+        return _check_mp4(filepath, probe)
+    if ext == ".aac":
+        return _check_adts(filepath, probe)
+    if ext == ".mp3":
+        return _check_mp3(filepath, probe)
+    if ext == ".flac":
+        return _check_flac(filepath, probe)
+    if ext in (".aif", ".aiff", ".aifc"):
+        return _check_aiff(filepath, probe)
+    return []
+
+
+def _check_adts(filepath: str, probe: dict) -> list[tuple[str, str]]:
+    """Check raw .aac (ADTS) files."""
+    findings = []
+    audio = next((s for s in probe["streams"] if s["codec_type"] == "audio"), None)
+    if audio is None:
+        return [(FAIL, "no audio stream found")]
+    profile = audio.get("profile") or ""
+    if "HE" in profile or "SBR" in profile:
+        findings.append((FAIL, f"AAC profile is {profile} - players decode AAC-LC only"))
+    findings.append(
+        (WARN, "raw ADTS .aac streams are unreliable on players - remux into .m4a: "
+               "ffmpeg -i in -c copy -bsf:a aac_adtstoasc out.m4a")
+    )
+    findings.extend(_check_rate_and_channels(audio, lossless=False))
+    return findings
+
+
+def collect_files(target: str) -> list[str]:
+    if os.path.isfile(target):
+        return [target]
+    collected = []
+    for root, _, names in os.walk(target):
+        for name in names:
+            if os.path.splitext(name)[1].lower() in AUDIO_EXTENSIONS:
+                collected.append(os.path.join(root, name))
+    return sorted(collected)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check audio files for hardware DJ player (CDJ/XDJ) compatibility."
+    )
+    parser.add_argument("target", help="Audio file or directory to scan", type=str)
+    parser.add_argument(
+        "--all", action="store_true", help="Also list files that pass every check"
+    )
+    args = parser.parse_args()
+
+    if shutil.which("ffprobe") is None:
+        print("ffprobe not found - install ffmpeg first (see README).")
+        sys.exit(2)
+
+    files = collect_files(args.target)
+    if not files:
+        print("No audio files found.")
+        sys.exit(0)
+
+    counts = {FAIL: 0, WARN: 0, "OK": 0}
+    for filepath in files:
+        findings = check_file(filepath)
+        worst = FAIL if any(l == FAIL for l, _ in findings) else (
+            WARN if findings else "OK"
+        )
+        counts[worst] += 1
+        if worst == "OK" and not args.all:
+            continue
+        print(f"[{worst}] {filepath}")
+        for level, message in findings:
+            print(f"       {level}: {message}")
+
+    print(
+        f"\nScanned {len(files)} file(s): "
+        f"{counts['OK']} ok, {counts[WARN]} warning(s), {counts[FAIL]} failing"
+    )
+    sys.exit(1 if counts[FAIL] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_handling.py
+++ b/src/data_handling.py
@@ -207,12 +207,19 @@ def find_closest_matching_result(
     not settle for a same-length but differently-versioned result."""
     db_duration = db_entry[COLUMN_TRACK_DURATION]
     expected = get_song_search_string(db_entry)
+    # A multi-artist collab's own name words (e.g. 3 credited artists) can by
+    # themselves clear is_title_match's overlap threshold even when the
+    # candidate is a completely different song by that same collab - the track
+    # name's own words barely move the ratio. Requiring at least one of them to
+    # actually appear closes that hole without needing an exact title match.
+    track_name_words = set(_normalize_search_words(db_entry[COLUMN_TRACK_NAME]))
     candidates = [
         result
         for result in search_results
         if abs(db_duration - result[duration_key]) / db_duration < duration_threshold
         and is_title_match(expected, result[title_key], threshold=title_threshold)
         and not has_unexpected_version_marker(expected, result[title_key])
+        and (not track_name_words or track_name_words & set(_normalize_search_words(result[title_key])))
     ]
     if not candidates:
         return None

--- a/src/device_profiles.py
+++ b/src/device_profiles.py
@@ -1,0 +1,52 @@
+"""Known audio format/quality ceilings for DJ hardware that plays files
+straight off a USB stick (standalone CDJ/XDJ players and the rekordbox
+library format itself).
+
+DDJ controllers are intentionally not modeled here: they have no onboard
+file reader, so whatever format plays is whatever software (rekordbox/
+Serato) running on the connected laptop supports - there's no DDJ-specific
+ceiling to target.
+
+Only ``max_mp3_kbps`` is wired into the conversion pipeline today, since
+output is MP3-only. The other fields describe what each device actually
+supports and are here so a future multi-format pipeline change can read
+them directly instead of re-deriving this table.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DeviceProfile:
+    formats: tuple[str, ...]
+    max_mp3_kbps: int
+    max_sample_rate_hz: int | None  # None = no device ceiling, passthrough from source
+    max_bit_depth: int | None  # applies to WAV/AIFF; None = not applicable/no ceiling
+
+
+DEVICE_PROFILES: dict[str, DeviceProfile] = {
+    "CDJ-3000 / XDJ-XZ (current gen)": DeviceProfile(
+        formats=("mp3", "wav", "aiff", "flac", "alac", "aac"),
+        max_mp3_kbps=320,
+        max_sample_rate_hz=96000,
+        max_bit_depth=24,
+    ),
+    "CDJ-2000NXS2 / XDJ-1000MK2": DeviceProfile(
+        formats=("mp3", "wav", "aiff", "aac"),
+        max_mp3_kbps=320,
+        max_sample_rate_hz=96000,
+        max_bit_depth=24,
+    ),
+    "CDJ-2000 / CDJ-900 (legacy)": DeviceProfile(
+        formats=("mp3", "wav", "aiff"),
+        max_mp3_kbps=320,
+        max_sample_rate_hz=48000,
+        max_bit_depth=16,
+    ),
+    "rekordbox library (software only)": DeviceProfile(
+        formats=("mp3", "wav", "aiff", "flac", "alac", "aac"),
+        max_mp3_kbps=320,
+        max_sample_rate_hz=None,
+        max_bit_depth=None,
+    ),
+}

--- a/src/device_profiles.py
+++ b/src/device_profiles.py
@@ -1,6 +1,12 @@
 """Known audio format/quality ceilings for DJ hardware that plays files
-straight off a USB stick (standalone CDJ/XDJ players and the rekordbox
-library format itself).
+straight off a USB stick (standalone CDJ/XDJ players).
+
+These two tiers - and the device models named in each - come directly from
+check_hardware_compat.py's own comments: that script already distinguishes
+exactly these two generations (FLAC/ALAC and hi-res sample rates play on one,
+not the other) without a formal table. This module gives that split a name so
+a device picker (or any other pipeline code) can reference it directly instead
+of re-deriving the same facts.
 
 DDJ controllers are intentionally not modeled here: they have no onboard
 file reader, so whatever format plays is whatever software (rekordbox/
@@ -9,8 +15,8 @@ ceiling to target.
 
 Only ``max_mp3_kbps`` is wired into the conversion pipeline today, since
 output is MP3-only. The other fields describe what each device actually
-supports and are here so a future multi-format pipeline change can read
-them directly instead of re-deriving this table.
+supports and are read directly by check_hardware_compat.py's per-device
+checks, and are here for a future multi-format pipeline change too.
 """
 
 from dataclasses import dataclass
@@ -18,6 +24,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class DeviceProfile:
+    name: str
     formats: tuple[str, ...]
     max_mp3_kbps: int
     max_sample_rate_hz: int | None  # None = no device ceiling, passthrough from source
@@ -25,28 +32,18 @@ class DeviceProfile:
 
 
 DEVICE_PROFILES: dict[str, DeviceProfile] = {
-    "CDJ-3000 / XDJ-XZ (current gen)": DeviceProfile(
+    "2016+ players (XDJ-1000MK2, NXS2, CDJ-3000, XDJ-AZ)": DeviceProfile(
+        name="2016+ players (XDJ-1000MK2, NXS2, CDJ-3000, XDJ-AZ)",
         formats=("mp3", "wav", "aiff", "flac", "alac", "aac"),
         max_mp3_kbps=320,
         max_sample_rate_hz=96000,
         max_bit_depth=24,
     ),
-    "CDJ-2000NXS2 / XDJ-1000MK2": DeviceProfile(
+    "Legacy players (CDJ-850, CDJ-900, CDJ-2000, XDJ-1000 mk1)": DeviceProfile(
+        name="Legacy players (CDJ-850, CDJ-900, CDJ-2000, XDJ-1000 mk1)",
         formats=("mp3", "wav", "aiff", "aac"),
         max_mp3_kbps=320,
-        max_sample_rate_hz=96000,
-        max_bit_depth=24,
-    ),
-    "CDJ-2000 / CDJ-900 (legacy)": DeviceProfile(
-        formats=("mp3", "wav", "aiff"),
-        max_mp3_kbps=320,
         max_sample_rate_hz=48000,
-        max_bit_depth=16,
-    ),
-    "rekordbox library (software only)": DeviceProfile(
-        formats=("mp3", "wav", "aiff", "flac", "alac", "aac"),
-        max_mp3_kbps=320,
-        max_sample_rate_hz=None,
-        max_bit_depth=None,
+        max_bit_depth=24,
     ),
 }

--- a/src/youtube_download.py
+++ b/src/youtube_download.py
@@ -54,7 +54,14 @@ def _download_mp4_video_from_youtube(
 
     print(f"\nDownloading '{filename.rstrip(FILE_EXTENSION_MP4)}'")
 
-    yt = YouTube(youtube_url)
+    # WEB_MUSIC is the client pytubefix's bundled botGuard PO-token generator
+    # actually works reliably with: the default ANDROID_VR client gets flagged
+    # as a bot on an increasing number of videos, and WEB (the client that
+    # activates PO-token generation) still fails on many of those with a SABR
+    # "PoToken PENDING" error during the actual chunked download. WEB_MUSIC
+    # both passes the bot check and returns a non-SABR stream, sidestepping
+    # that failure mode entirely.
+    yt = YouTube(youtube_url, client="WEB_MUSIC")
 
     # Get stream with video in mp4 format, order by Average Bit Rate and take highest bit rate
     video = yt.streams.filter(subtype="mp4").order_by("abr").last()
@@ -73,7 +80,7 @@ def _download_mp4_audio_from_youtube(
 
     print(f"\nDownloading '{filename.rstrip(FILE_EXTENSION_MP4)}'")
 
-    yt = YouTube(youtube_url)
+    yt = YouTube(youtube_url, client="WEB_MUSIC")
 
     # Get stream with only audio in mp4 format, order by Average Bit Rate and take highest bit rate
     video = yt.streams.filter(only_audio=True, subtype="mp4").order_by("abr").last()


### PR DESCRIPTION
## Summary

Adds device-aware hardware-compatibility checking for DJ players (CDJ/XDJ), built directly on top of **#22** (`check_hardware_compat.py` by @eistrup).

**Credit where due:** this PR includes eistrup's original commit (`56ca10b`, "Add hardware-compatibility checker for DJ players") unchanged as its base, then extends it with a device-profile table and UI wiring so the checker's output actually depends on which player you're targeting instead of one generic warning set. `#22` should probably be closed as superseded by this once it's merged, rather than merged separately — happy to discuss if you'd rather land them independently.

## What's in it

**From #22 (unchanged):**
- `check_hardware_compat.py` — scans audio files for known hardware-player failure modes: fragmented DASH MP4 containers, unsupported codecs (HE-AAC, Opus/Vorbis, ALAC), WAV traps (32-bit/float samples, `WAVE_FORMAT_EXTENSIBLE` headers), out-of-range sample rates, oversized ID3v2 tags, mislabeled files, and more.

**New on top:**

- **`src/device_profiles.py`** — a `DEVICE_PROFILES` table naming the two device generations `check_hardware_compat.py`'s own comments already implicitly distinguished (rather than inventing a new taxonomy):
  - `"2016+ players (XDJ-1000MK2, NXS2, CDJ-3000, XDJ-AZ)"` — MP3/WAV/AIFF/FLAC/ALAC/AAC, up to 320kbps MP3, 96kHz/24-bit
  - `"Legacy players (CDJ-850, CDJ-900, CDJ-2000, XDJ-1000 mk1)"` — MP3/WAV/AIFF/AAC only, up to 320kbps MP3, 48kHz ceiling

- **`check_hardware_compat.py` (extended)** — every check now takes an optional `device_profile`. A hi-res sample rate or FLAC/ALAC track that used to always emit the same generic `WARN` now resolves per device: a clean pass on a device that supports it, a hard `FAIL` on one that doesn't (with the specific ceiling named in the message), or the original generic `WARN` when no device is selected. Also derives `SAFE_SAMPLE_RATES`/`HIRES_SAMPLE_RATES` from `DEVICE_PROFILES` instead of hardcoding them separately, and adds a `--device` flag to the CLI for the same behavior standalone.

- **`app.py`** — a new "Target device" dropdown (defaults to "Custom", preserving the original manual bitrate controls). Picking a device caps the MP3 bitrate at its ceiling and shows a caption of what it supports. Every downloaded track is checked against the selected device on arrival (direct SoundCloud download, post-conversion from YouTube, and skip-if-already-downloaded reruns) and shows a badge on its card — orange "⚠ N" for warnings, red "⛔ N" for failures — with the specific findings in a hover tooltip.

- **`src/youtube_download.py`** — switched the `YouTube(...)` client from the default `ANDROID_VR` to `WEB_MUSIC`. `ANDROID_VR` was getting flagged by YouTube's bot detection (`BotDetection`) on an increasing number of videos; `WEB` (the other PO-token-capable client) passes that check but then hits a separate `SABRError: PoToken PENDING` failure during the actual chunked download on the same videos. `WEB_MUSIC` passes both and returns a non-SABR stream, sidestepping that failure mode entirely. No new dependency — `pytubefix` already bundles a local Node.js binary (`nodejs-wheel-binaries`) and generates PO tokens automatically via its own bundled `botGuard.js`.

- **`src/data_handling.py`** — fixed a matching false-positive affecting both SoundCloud and YouTube Music matching: for a multi-artist collab track (e.g. 3 credited artists), the shared artist-name words alone could clear the title-similarity threshold even when the candidate was a *completely different song* by the same artists and the actual track name didn't appear at all. Concretely: matching "System" by Odd Mob, OMNOM, HYPERBEAM incorrectly matched a SoundCloud result for "All Day, All Night" by the same three artists, because 4 of the 5 "expected" words were just the artist names. Now requires at least one of the track name's own words to actually appear in the candidate, closing the hole without needing an exact title match.

## Test plan

- Verified device-aware severity resolution against synthetic WAV files at 44.1/48/96kHz: same file resolves to pass / generic WARN / device-specific FAIL depending on which device (if any) is selected.
- Ran the full Streamlit app in a browser end-to-end — uploaded a real playlist, selected a device, let it actually match/download/convert through SoundCloud, confirmed the device dropdown, MP3 bitrate capping, and compat badges all render and update correctly; cross-checked the "no badge" case directly against the CLI to confirm it reflects a genuine zero-findings pass rather than a silent failure.
- Verified the YouTube client fix: reproduced `BotDetection` failures on real videos with the old client, confirmed `WEB_MUSIC` downloads them successfully end-to-end through the actual `get_audio_from_youtube()` function.
- Verified the matching fix: confirmed it rejects the bad "System" → "All Day, All Night" cross-match, still accepts a normal single-artist match, and correctly matches the real "System" track afterward on both SoundCloud and YouTube Music search.

## Known limitations / follow-ups (not in this PR)

- Output is still MP3-only — device profiles inform bitrate capping and compat warnings today, but sample rate/bit depth/format aren't enforced by the encoder yet. A follow-up pipeline change (multi-format ffmpeg output) would let `check_hardware_compat.py` findings become fixes instead of just warnings.
- Some tracks only exist on SoundCloud as a longer edit (e.g. "Extended Mix") than the playlist's expected duration, so they currently fall back to YouTube rather than ever matching on SoundCloud. Deferred to a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
