### PR TITLE
Show a sidebar notice instead of crashing when SPOTIFY_CLIENT_ID is unset

### DIFF
--- a/app.py
+++ b/app.py
@@ -549,6 +549,13 @@ def render_spotify_sidebar():
     Exportify's own login-then-pick flow instead of asking for a pasted URL."""
     st.sidebar.subheader("Spotify")
 
+    if not SPOTIFY_CLIENT_ID:
+        st.sidebar.warning(
+            "Spotify login is disabled: set SPOTIFY_CLIENT_ID in a .env file "
+            "(see .env.example). You can still upload an Exportify CSV below."
+        )
+        return
+
     if "spotify_client" not in st.session_state:
         cached_client = get_cached_spotify_client(SPOTIFY_CLIENT_ID)
         if cached_client:


### PR DESCRIPTION
## Summary
- Without a `.env`, `render_spotify_sidebar` built a `SpotifyPKCE` client with an empty `client_id`, raising `SpotifyOauthError` at module level and killing the entire page before the CSV workflow could render.
- Now, when `SPOTIFY_CLIENT_ID` is empty, the sidebar shows a warning pointing to `.env` setup and returns early, so the CSV-upload workflow stays fully usable without any Spotify configuration.

## Test plan
- Ran `streamlit run app.py` with no `.env`: page renders fully, sidebar shows the notice, CSV upload/Match/Download/Convert flow available.
- With `SPOTIFY_CLIENT_ID` set, behavior is unchanged (login flow renders as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)