### PR TITLE
Add YouTube playlist URL as a playlist source

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ poetry run streamlit run app.py
 
 Then point it at an Exportify CSV (or a CSV that already has a "Youtube ID" column)
 and click Start. Matching, downloading and MP3 conversion run one after another,
-with progress bars and logs for each stage.
+with progress bars and logs for each stage. You can also log into Spotify or Tidal
+to pick a playlist directly, or paste a public/unlisted YouTube playlist URL —
+YouTube tracks arrive pre-matched, so the Matching step is skipped.
 
 ## Main Workflow
 

--- a/app.py
+++ b/app.py
@@ -76,6 +76,9 @@ from src.youtube_music_search import (
     find_best_matching_youtube_music_video,
     get_youtube_music_search_results,
 )
+from src.youtube_playlist_export import YoutubePlaylistUnavailableError
+from src.youtube_playlist_export import export_playlist_to_csv as export_youtube_playlist_to_csv
+from src.youtube_playlist_export import extract_playlist_id as extract_youtube_playlist_id
 
 # Covers HTTP errors from Spotify (SpotifyException), OAuth-specific failures
 # (SpotifyOauthError - both share the SpotifyBaseException base), and raw
@@ -87,6 +90,11 @@ SPOTIFY_ERRORS = (requests.RequestException, spotipy.SpotifyBaseException)
 # Same idea again, for Tidal: network failures plus every tidalapi-raised error
 # (TidalAPIError is the common base for all of them).
 TIDAL_ERRORS = (requests.RequestException, tidalapi.exceptions.TidalAPIError)
+
+# And for the YouTube playlist source: network failures plus the module's own
+# "couldn't fetch that playlist" error (which already wraps ytmusicapi's raw
+# failure modes into a user-friendly message).
+YOUTUBE_ERRORS = (requests.RequestException, YoutubePlaylistUnavailableError)
 
 STATE_PENDING = "Pending"
 STATE_MATCHED = "Matched"
@@ -169,7 +177,8 @@ SPOTIFY_SIDEBAR_STYLE = (
 )
 
 # Small original glyphs evoking each service's mark (not a reproduction of the
-# real trademarked artwork): Spotify's soundwave arcs, Tidal's diamond "T".
+# real trademarked artwork): Spotify's soundwave arcs, Tidal's diamond "T",
+# YouTube's play triangle.
 # Two variants each:
 # - "glyph" is transparent-background, `currentColor` only - used on the active
 #   tab, which already supplies the brand-colored background itself.
@@ -209,12 +218,25 @@ TIDAL_LOGO_BADGE_SVG = (
     '<rect x="10.5" y="12.62" width="3" height="3" fill="white" transform="rotate(45 12 14.12)"/>'
     "</svg>"
 )
+YOUTUBE_LOGO_GLYPH_SVG = (
+    '<svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
+    '<rect x="3" y="6.5" width="18" height="11" rx="3" stroke="currentColor" stroke-width="1.8" fill="none"/>'
+    '<path d="M10.5 9.5L15 12L10.5 14.5Z" fill="currentColor"/>'
+    "</svg>"
+)
+YOUTUBE_LOGO_BADGE_SVG = (
+    '<svg width="22" height="22" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
+    '<rect x="1" y="4.5" width="22" height="15" rx="4" fill="#FF0000"/>'
+    '<path d="M9.8 8.8L15.5 12L9.8 15.2Z" fill="white"/>'
+    "</svg>"
+)
 
 # (name, active-state glyph svg, inactive-state badge svg, brand color) for the
 # playlist-source tab bar.
 PLAYLIST_SOURCES = [
     ("Spotify", SPOTIFY_LOGO_GLYPH_SVG, SPOTIFY_LOGO_BADGE_SVG, "#1DB954"),
     ("Tidal", TIDAL_LOGO_GLYPH_SVG, TIDAL_LOGO_BADGE_SVG, "#000000"),
+    ("YouTube", YOUTUBE_LOGO_GLYPH_SVG, YOUTUBE_LOGO_BADGE_SVG, "#FF0000"),
 ]
 
 # Zero gap between the three source-tab columns, so they sit flush against
@@ -434,7 +456,7 @@ def extract_youtube_id(text: str):
 
 st.set_page_config(page_title="Track Tracker", page_icon="🎵", layout="wide")
 st.title("Track Tracker")
-st.caption("Turn a Spotify or Tidal playlist into a folder of tagged MP3s.")
+st.caption("Turn a Spotify, Tidal or YouTube playlist into a folder of tagged MP3s.")
 
 
 def build_tracks(csv_path: str):
@@ -521,6 +543,20 @@ def handle_tidal_playlist_selected(playlist: dict):
         csv_bytes = f.read()
     csv_name = sanitize_filename(playlist["name"]) + ".csv"
     activate_csv_source(csv_bytes, csv_name, f"tidal:{playlist['id']}")
+
+
+def handle_youtube_playlist_url(playlist_id: str) -> int:
+    """Export the pasted YouTube playlist to a CSV and load it exactly like an
+    upload. Returns how many unavailable entries were skipped, so the sidebar
+    can mention them."""
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_csv_path = tmp.name
+    playlist_title, skipped = export_youtube_playlist_to_csv(playlist_id, tmp_csv_path)
+    with open(tmp_csv_path, "rb") as f:
+        csv_bytes = f.read()
+    csv_name = sanitize_filename(playlist_title) + ".csv"
+    activate_csv_source(csv_bytes, csv_name, f"youtube:{playlist_id}")
+    return skipped
 
 
 def handle_oauth_callback():
@@ -690,6 +726,50 @@ def render_tidal_sidebar():
                     st.rerun()
 
 
+def render_youtube_sidebar():
+    """Left pane: paste a YouTube/YouTube Music playlist URL. No login flow at
+    all (unauthenticated ytmusicapi handles public/unlisted playlists), and no
+    picker list - one URL is one playlist, so it activates immediately."""
+    st.sidebar.subheader("YouTube")
+
+    # One-shot note from the previous run's activation, surfaced after the
+    # rerun so it isn't lost with the rest of that script run's output.
+    skipped_note = st.session_state.pop("youtube_skipped_note", None)
+    if skipped_note:
+        st.sidebar.caption(skipped_note)
+
+    st.sidebar.caption(
+        "Paste a link to a public or unlisted YouTube / YouTube Music "
+        "playlist - no login needed. Its videos are used directly, so tracks "
+        "arrive pre-matched and the Matching step is skipped."
+    )
+    url_col, go_col = st.sidebar.columns([3, 1])
+    with url_col:
+        playlist_url = st.text_input(
+            "YouTube playlist URL",
+            key="youtube_playlist_url",
+            label_visibility="collapsed",
+            placeholder="youtube.com/playlist?list=...",
+        )
+    with go_col:
+        go_clicked = st.button("➜", key="youtube_playlist_go", width="stretch")
+    if not go_clicked:
+        return
+
+    playlist_id = extract_youtube_playlist_id(playlist_url)
+    if not playlist_id:
+        st.sidebar.error("Couldn't find a playlist ID in that link.")
+        return
+    try:
+        skipped = handle_youtube_playlist_url(playlist_id)
+    except YOUTUBE_ERRORS as exc:
+        st.sidebar.error(str(exc))
+        return
+    if skipped:
+        st.session_state["youtube_skipped_note"] = f"{skipped} unavailable track(s) skipped."
+    st.rerun()
+
+
 def render_source_tab_bar():
     """Tabs for picking the playlist source, flush against each other with no
     gaps: each tab is a flat badge in its own brand color, a small square when
@@ -727,8 +807,10 @@ def render_playlist_sidebar():
     source = st.session_state.playlist_source
     if source == "Spotify":
         render_spotify_sidebar()
-    else:
+    elif source == "Tidal":
         render_tidal_sidebar()
+    else:
+        render_youtube_sidebar()
 
 
 render_playlist_sidebar()

--- a/src/youtube_playlist_export.py
+++ b/src/youtube_playlist_export.py
@@ -1,0 +1,100 @@
+"""Module for exporting a public/unlisted YouTube (or YouTube Music) playlist
+straight to CSV from a pasted URL - no login needed, unlike the Spotify/Tidal
+sources. Uses unauthenticated ytmusicapi (already a dependency for matching),
+which resolves regular YouTube playlists (PL...), YouTube Music playlists and
+album share links (OLAK5uy_...) alike.
+
+Every entry already carries its videoId, so the CSV is written in the
+"with IDs" shape (same header as template_with_ids.csv) - the app's matching
+stage is skipped entirely and rows arrive pre-matched. Duration is therefore
+written directly in seconds: `get_data_list_from_csv_with_ids` does no ms->s
+normalization."""
+import re
+from typing import Optional, Tuple
+
+from ytmusicapi import YTMusic
+
+from src.csv_handling import write_csv
+from src.data_handling import (
+    COLUMN_ARTIST_NAME,
+    COLUMN_GENRES,
+    COLUMN_TEMPO,
+    COLUMN_TRACK_DURATION,
+    COLUMN_TRACK_NAME,
+    COLUMN_YOUTUBE_ID,
+)
+
+EXPORT_COLUMNS = [
+    COLUMN_ARTIST_NAME,
+    COLUMN_TRACK_NAME,
+    COLUMN_TRACK_DURATION,
+    COLUMN_GENRES,
+    COLUMN_TEMPO,
+    COLUMN_YOUTUBE_ID,
+]
+
+YOUTUBE_PLAYLIST_URL_RE = re.compile(r"[?&]list=([A-Za-z0-9_-]+)")
+YOUTUBE_PLAYLIST_ID_RE = re.compile(r"^[A-Za-z0-9_-]{12,}$")
+
+
+class YoutubePlaylistUnavailableError(Exception):
+    """The playlist couldn't be fetched (private, deleted, or not a playlist)."""
+
+
+def extract_playlist_id(text: str) -> Optional[str]:
+    """Pull a playlist ID out of a pasted YouTube/YouTube Music URL (any URL
+    with a `list=` param, including watch?v=...&list=...), or accept a raw ID
+    directly. Strips the "VL" prefix from share links - ytmusicapi prepends it
+    itself."""
+    text = (text or "").strip()
+    if not text:
+        return None
+    match = YOUTUBE_PLAYLIST_URL_RE.search(text)
+    playlist_id = match.group(1) if match else (text if YOUTUBE_PLAYLIST_ID_RE.match(text) else None)
+    if playlist_id and playlist_id.startswith("VL"):
+        playlist_id = playlist_id[2:]
+    return playlist_id
+
+
+def export_playlist_to_csv(playlist_id: str, output_path: str) -> Tuple[str, int]:
+    """Fetch a playlist's entries and write them to a with-IDs CSV. Returns
+    (playlist title, number of skipped entries) - unlike the other sources
+    there's no picker supplying a name, so the title comes back from here to
+    name the CSV (and thus the download folder).
+
+    Unavailable entries (deleted/private videos come back with videoId None)
+    are skipped rather than left Pending: auto-matching them from a
+    possibly-wrong title would silently download the wrong thing."""
+    try:
+        playlist = YTMusic().get_playlist(playlist_id, limit=None)
+    except Exception as exc:
+        # ytmusicapi surfaces private/nonexistent playlists as raw KeyErrors
+        # from its response navigation, so any failure here gets one message.
+        raise YoutubePlaylistUnavailableError(
+            "Couldn't fetch that playlist - it may be private, deleted, or not a playlist link."
+        ) from exc
+
+    rows = []
+    skipped = 0
+    for track in playlist.get("tracks") or []:
+        video_id = track.get("videoId")
+        duration_seconds = track.get("duration_seconds")
+        if not video_id or duration_seconds is None:
+            skipped += 1
+            continue
+        artist_names = ", ".join(
+            artist["name"] for artist in (track.get("artists") or []) if artist.get("name")
+        )
+        rows.append(
+            {
+                COLUMN_ARTIST_NAME: artist_names,
+                COLUMN_TRACK_NAME: track.get("title") or "",
+                COLUMN_TRACK_DURATION: duration_seconds,
+                COLUMN_GENRES: "",
+                COLUMN_TEMPO: "",
+                COLUMN_YOUTUBE_ID: video_id,
+            }
+        )
+
+    write_csv(output_path, rows, EXPORT_COLUMNS)
+    return playlist.get("title") or "YouTube Playlist", skipped


### PR DESCRIPTION
## Summary
- New "YouTube" tab in the playlist-source sidebar: paste a link to a public or unlisted YouTube / YouTube Music playlist (or an `OLAK5uy_...` album share link) — no login or OAuth needed.
- Entries are fetched via unauthenticated `ytmusicapi` (already a declared dependency, used by the matching stage), in the new `src/youtube_playlist_export.py`, mirroring `src/tidal_export.py`'s shape.
- The CSV is written in the with-IDs shape (`Artist Name(s),Track Name,Duration (s),Genres,Tempo,Youtube ID`), so every track arrives pre-matched and the Matching stage is skipped entirely — the playlist's own videos are downloaded directly.
- Unavailable entries (deleted/private videos come back with `videoId: None`) are skipped with a sidebar note instead of being left Pending, where auto-matching from a possibly-wrong title could silently download the wrong thing.
- URL parsing accepts `youtube.com/playlist?list=...`, `music.youtube.com/...`, `watch?v=...&list=...`, bare playlist IDs, and strips the `VL` share-link prefix (ytmusicapi adds it itself). Private/nonexistent playlists show a friendly error instead of a traceback.

## Test plan
- Unit-checked `extract_playlist_id` across all URL variants above.
- Live-fetched a public 200-track playlist: correct title, all 200 rows with video IDs, header matching `template_with_ids.csv`; a nonexistent playlist ID raises the friendly `YoutubePlaylistUnavailableError`.
- Ran the Streamlit UI end-to-end: YouTube tab renders, pasting the playlist URL loads all tracks in **Matched** state with working per-track YouTube links, Match step shows nothing pending, Start/Download enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)