### PR TITLE
Fall back to a stripped query when "Original Mix" breaks search ranking

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ from src.data_handling import (
     get_data_list_from_exportify_csv,
     get_song_filename,
     get_song_search_string,
+    get_song_search_string_variants,
     get_youtube_url,
     sanitize_filename,
 )
@@ -1021,42 +1022,57 @@ def render_tracks():
 render_tracks()
 
 
+def _find_soundcloud_match(row: dict, search_strings: list) -> str:
+    """Try each query variant in order (see get_song_search_string_variants),
+    returning the first match found, or None if none of them match."""
+    for search_string in search_strings:
+        try:
+            results = search_soundcloud_tracks(search_string)
+            return find_best_matching_soundcloud_track(db_entry=row, search_results=results)
+        except NoMatchingSoundcloudTrackFoundError:
+            continue
+        except Exception as exc:
+            # SoundCloud is an unofficial API (scraped client_id, reverse-engineered
+            # endpoints) - any failure here just means falling back to YouTube,
+            # not failing the match.
+            print(f"SoundCloud search failed for '{search_string}': {exc}")
+            continue
+    return None
+
+
+def _find_youtube_music_match(row: dict, search_strings: list) -> str:
+    """Try each query variant in order (see get_song_search_string_variants),
+    returning the first match found, or None if none of them match."""
+    for search_string in search_strings:
+        try:
+            results = get_youtube_music_search_results(search_string)
+            return find_best_matching_youtube_music_video(db_entry=row, search_results=results)
+        except NoMatchingYoutubeMusicVideoFoundError:
+            continue
+    return None
+
+
 def run_matching_stage():
     pending_rows = [row for row in st.session_state.tracks if row["State"] == STATE_PENDING]
     total = len(pending_rows)
     if total == 0:
         return
     for row in pending_rows:
-        search_string = get_song_search_string(row)
+        search_strings = get_song_search_string_variants(row)
 
-        soundcloud_url = None
-        try:
-            soundcloud_results = search_soundcloud_tracks(search_string)
-            soundcloud_url = find_best_matching_soundcloud_track(
-                db_entry=row, search_results=soundcloud_results
-            )
-        except NoMatchingSoundcloudTrackFoundError:
-            pass
-        except Exception as exc:
-            # SoundCloud is an unofficial API (scraped client_id, reverse-engineered
-            # endpoints) - any failure here just means falling back to YouTube below,
-            # not failing the match.
-            print(f"SoundCloud search failed for '{search_string}': {exc}")
-
+        soundcloud_url = _find_soundcloud_match(row, search_strings)
         if soundcloud_url:
             row[COLUMN_SOUNDCLOUD_URL] = soundcloud_url
             row["State"] = STATE_MATCHED
             render_tracks()
             continue
 
-        try:
-            results = get_youtube_music_search_results(search_string)
-            video_id = find_best_matching_youtube_music_video(db_entry=row, search_results=results)
-        except NoMatchingYoutubeMusicVideoFoundError:
-            row["State"] = STATE_NO_MATCH
-        else:
+        video_id = _find_youtube_music_match(row, search_strings)
+        if video_id:
             row[COLUMN_YOUTUBE_ID] = video_id
             row["State"] = STATE_MATCHED
+        else:
+            row["State"] = STATE_NO_MATCH
         render_tracks()
 
 
@@ -1078,8 +1094,12 @@ def _download_track_audio(row: dict, download_dir: str, song_filename: str) -> s
             row[COLUMN_SOUNDCLOUD_URL] = ""
 
     if not row.get(COLUMN_YOUTUBE_ID):
-        results = get_youtube_music_search_results(get_song_search_string(row))
-        row[COLUMN_YOUTUBE_ID] = find_best_matching_youtube_music_video(db_entry=row, search_results=results)
+        video_id = _find_youtube_music_match(row, get_song_search_string_variants(row))
+        if video_id is None:
+            raise NoMatchingYoutubeMusicVideoFoundError(
+                f"Unable to find a matching YouTube Music video for {get_song_search_string(row)}"
+            )
+        row[COLUMN_YOUTUBE_ID] = video_id
 
     return get_audio_from_youtube(
         youtube_url=get_youtube_url(row), output_dir=download_dir, filename=song_filename

--- a/src/data_handling.py
+++ b/src/data_handling.py
@@ -101,6 +101,29 @@ def get_song_search_string(music_row: Dict) -> str:
     return f"{music_row[COLUMN_ARTIST_NAME]} - {music_row[COLUMN_TRACK_NAME]}"
 
 
+_TRAILING_ORIGINAL_MIX_RE = re.compile(r"\s*-\s*original\s+mix\s*$", re.IGNORECASE)
+
+
+def get_song_search_string_variants(music_row: Dict) -> List[str]:
+    """Query strings to try against a search source, most-preferred first.
+
+    A literal trailing "- Original Mix" in the query text throws off YouTube
+    Music's search ranking - verified empirically: the exact same query with
+    that suffix stripped finds the correct track as the #1 result, while
+    keeping it returns unrelated tracks. The full query (with "Original Mix")
+    is tried first since it's the more precise, preferred match target; a
+    second variant with the suffix stripped is offered only as a fallback for
+    when the full query's results don't produce a match. Matching itself
+    (duration/title thresholds) is unaffected either way - this only changes
+    what's typed into the search box, not what counts as a match."""
+    full = get_song_search_string(music_row)
+    track_name = music_row[COLUMN_TRACK_NAME]
+    stripped_track_name = _TRAILING_ORIGINAL_MIX_RE.sub("", track_name)
+    if stripped_track_name == track_name:
+        return [full]
+    return [full, f"{music_row[COLUMN_ARTIST_NAME]} - {stripped_track_name}"]
+
+
 def get_youtube_url(music_row: Dict) -> str:
     """Helper function to generate the youtube URL for a song."""
     return f"https://www.youtube.com/watch?v={music_row[COLUMN_YOUTUBE_ID]}"


### PR DESCRIPTION
A literal trailing "- Original Mix" in a search query throws off YouTube Music's ranking - verified empirically on a real track ("Synthatic, Klipsun - The House - Original mix"): the identical query with that suffix removed finds the correct track as the #1 result, while keeping it returns unrelated songs entirely. SoundCloud's search turned out to have the same blind spot for this track, missing a second legitimate upload that the stripped query does surface.

get_song_search_string_variants() returns the full query first (preferred, tried first) and a second variant with the trailing "- Original Mix" stripped only when present, tried only as a fallback when the full query's results produce no match. Matching itself (duration/title thresholds, version-marker checks) is completely unchanged either way - this only changes what's typed into the search box, never what counts as an acceptable match. Applied consistently everywhere a query is built for search: the matching stage and the download-time YouTube re-search fallback.

Verified end-to-end through the real app: the track that prompted this now matches directly via SoundCloud (a second real upload the "Original Mix" query was also missing) instead of falling through to YouTube. Confirmed separately that a wrong duration still correctly fails to match on both query variants.